### PR TITLE
Use origin access identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
           matrix='{
             "env":[
               {
-                "tf_version":"0.13.2",
+                "tf_version":"0.13.4",
                 "tf_working_dir":"./examples/ci-13",
                 "aws_key_name":"byu_oit_terraform_dev_key",
                 "aws_secret_name":"byu_oit_terraform_dev_secret"
               },
               {
-                "tf_version":"0.12.26",
+                "tf_version":"0.12.29",
                 "tf_working_dir":"./examples/ci-12",
                 "aws_key_name":"byu_oit_terraform_dev_key",
                 "aws_secret_name":"byu_oit_terraform_dev_secret"

--- a/README.md
+++ b/README.md
@@ -28,17 +28,18 @@ module "s3_site" {
 ![First Terraform Error](readme/terraform-apply-1.png)
 
 ## Inputs
-| Name                   | Type        | Description                                                                       | Default        |
-| ---------------------- | ----------- | --------------------------------------------------------------------------------- | -------------- |
-| hosted_zone_id         | string      | Hosted Zone ID                                                                    |
-| index_doc              | string      | The index document of the site.                                                   | index.html     |
-| encryption_key_id      | string      | The AWS KMS master key ID used for the SSE-KMS encryption                         | 
-| site_url               | string      | The URL for the site.                                                             |
-| wait_for_deployment    | string      | Define if Terraform should wait for the distribution to deploy before completing. | `true`         |
-| s3_bucket_name         | string      | Name of S3 bucket for the website                                                 |
-| tags                   | map(string) | A map of AWS Tags to attach to each resource created                              | {}             |
-| cloudfront_price_class | string      | The price class for the cloudfront distribution                                   | PriceClass_100 |
-| cors_rules             | list(object) | The CORS policies for S3 bucket                                                  | []             |
+| Name                   | Type         | Description                                                                       | Default        |
+| ---------------------- | ------------ | --------------------------------------------------------------------------------- | -------------- |
+| hosted_zone_id         | string       | Hosted Zone ID                                                                    |
+| index_doc              | string       | The index document of the site.                                                   | index.html     |
+| encryption_key_id      | string       | The AWS KMS master key ID used for the SSE-KMS encryption                         | 
+| site_url               | string       | The URL for the site.                                                             |
+| wait_for_deployment    | string       | Define if Terraform should wait for the distribution to deploy before completing. | `true`         |
+| s3_bucket_name         | string       | Name of S3 bucket for the website                                                 |
+| tags                   | map(string)  | A map of AWS Tags to attach to each resource created                              | {}             |
+| cloudfront_price_class | string       | The price class for the cloudfront distribution                                   | PriceClass_100 |
+| cors_rules             | list(object) | The CORS policies for S3 bucket                                                   | []             |
+| log_cookies            | bool         | Include cookies in the CloudFront access logs.                                    |                |
 ## Outputs
 | Name            | Type                                                                                                     | Description                                             |
 | --------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ module "s3_site" {
 | ---------------------- | ----------- | --------------------------------------------------------------------------------- | -------------- |
 | hosted_zone_id         | string      | Hosted Zone ID                                                                    |
 | index_doc              | string      | The index document of the site.                                                   | index.html     |
-| encryption_key_id      | string      | The AWS KMS master key ID used for the SSE-KMS encryption                         | aws/s3
+| encryption_key_id      | string      | The AWS KMS master key ID used for the SSE-KMS encryption                         | 
 | site_url               | string      | The URL for the site.                                                             |
 | wait_for_deployment    | string      | Define if Terraform should wait for the distribution to deploy before completing. | `true`         |
 | s3_bucket_name         | string      | Name of S3 bucket for the website                                                 |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ module "s3_site" {
 | ---------------------- | ----------- | --------------------------------------------------------------------------------- | -------------- |
 | hosted_zone_id         | string      | Hosted Zone ID                                                                    |
 | index_doc              | string      | The index document of the site.                                                   | index.html     |
-| error_doc              | string      | The error document (e.g. 404 page) of the site.                                   | index.html     |
 | site_url               | string      | The URL for the site.                                                             |
 | wait_for_deployment    | string      | Define if Terraform should wait for the distribution to deploy before completing. | `true`         |
 | s3_bucket_name         | string      | Name of S3 bucket for the website                                                 |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Terraform module deploys an S3-hosted static site with HTTPS enabled.
 ## Usage
 ```hcl
 module "s3_site" {
-  source    = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v4.0.1"
+  source    = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v5.0.0"
   site_url       = "my-site.byu.edu"
   hosted_zone_id = "zoneid"
   s3_bucket_name = "bucket-name"
@@ -33,7 +33,6 @@ module "s3_site" {
 | hosted_zone_id         | string      | Hosted Zone ID                                                                    |
 | index_doc              | string      | The index document of the site.                                                   | index.html     |
 | error_doc              | string      | The error document (e.g. 404 page) of the site.                                   | index.html     |
-| origin_path            | string      | The path to the file in the S3 bucket (no trailing slash).                        | *Empty string* |
 | site_url               | string      | The URL for the site.                                                             |
 | wait_for_deployment    | string      | Define if Terraform should wait for the distribution to deploy before completing. | `true`         |
 | s3_bucket_name         | string      | Name of S3 bucket for the website                                                 |

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ module "s3_site" {
 | ---------------------- | ------------ | --------------------------------------------------------------------------------- | -------------- |
 | hosted_zone_id         | string       | Hosted Zone ID                                                                    |
 | index_doc              | string       | The index document of the site.                                                   | index.html     |
-| encryption_key_id      | string       | The AWS KMS master key ID used for the SSE-KMS encryption                         | 
+| encryption_key_id      | string       | The AWS KMS master key ID used for the SSE-KMS encryption                         | `aws/s3`
 | site_url               | string       | The URL for the site.                                                             |
-| wait_for_deployment    | string       | Define if Terraform should wait for the distribution to deploy before completing. | `true`         |
+| wait_for_deployment    | bool         | Define if Terraform should wait for the distribution to deploy before completing. | `true`         |
 | s3_bucket_name         | string       | Name of S3 bucket for the website                                                 |
 | tags                   | map(string)  | A map of AWS Tags to attach to each resource created                              | {}             |
 | cloudfront_price_class | string       | The price class for the cloudfront distribution                                   | PriceClass_100 |
 | cors_rules             | list(object) | The CORS policies for S3 bucket                                                   | []             |
-| log_cookies            | bool         | Include cookies in the CloudFront access logs.                                    |                |
+| log_cookies            | bool         | Include cookies in the CloudFront access logs.                                    | false          |
 ## Outputs
 | Name            | Type                                                                                                     | Description                                             |
 | --------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ module "s3_site" {
 | ---------------------- | ----------- | --------------------------------------------------------------------------------- | -------------- |
 | hosted_zone_id         | string      | Hosted Zone ID                                                                    |
 | index_doc              | string      | The index document of the site.                                                   | index.html     |
+| encryption_key_id      | string      | The AWS KMS master key ID used for the SSE-KMS encryption                         | aws/s3
 | site_url               | string      | The URL for the site.                                                             |
 | wait_for_deployment    | string      | Define if Terraform should wait for the distribution to deploy before completing. | `true`         |
 | s3_bucket_name         | string      | Name of S3 bucket for the website                                                 |

--- a/examples/ci-12/ci.tf
+++ b/examples/ci-12/ci.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.12.26"
+  required_version = "0.12.29"
 }
 
 provider "aws" {

--- a/examples/ci-13/ci.tf
+++ b/examples/ci-13/ci.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.13.2"
+  required_version = "0.13.4"
 }
 
 provider "aws" {

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -10,8 +10,8 @@ data "aws_route53_zone" "zone" {
 }
 
 module "s3_site" {
-  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v5.0.0"
-  //  source         = "../../"
+  //  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v5.0.0"
+  source         = "../../"
   site_url       = "teststatic.byu-oit-terraform-dev.amazon.byu.edu"
   hosted_zone_id = data.aws_route53_zone.zone.id
   s3_bucket_name = "terraform-module-dev-s3staticsite"

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -10,7 +10,7 @@ data "aws_route53_zone" "zone" {
 }
 
 module "s3_site" {
-  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v4.0.1"
+  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v5.0.0"
   //  source         = "../../"
   site_url       = "teststatic.byu-oit-terraform-dev.amazon.byu.edu"
   hosted_zone_id = data.aws_route53_zone.zone.id

--- a/main.tf
+++ b/main.tf
@@ -119,11 +119,6 @@ resource "aws_s3_bucket" "website" {
   bucket = var.s3_bucket_name
   tags   = var.tags
 
-  website {
-    index_document = var.index_doc
-    error_document = var.error_doc
-  }
-
   lifecycle_rule {
     enabled                                = true
     abort_incomplete_multipart_upload_days = 10

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,5 +7,5 @@ output "cf_distribution" {
 }
 
 output "dns_record" {
-  value = aws_route53_record.custom-url-a
+  value = aws_route53_record.custom_url_a
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,16 +4,10 @@ variable "index_doc" {
   description = "The index document of the site."
 }
 
-variable "error_doc" {
-  type        = string
-  default     = "index.html"
-  description = "The error document (e.g. 404 page) of the site."
-}
-
-variable "origin_path" {
-  type        = string
-  default     = ""
-  description = "The path to the file in the S3 bucket (no trailing slash)."
+variable "encryption_key_id" {
+  type = string
+  default = "aws/s3"
+  description = "The AWS KMS master key ID used for the SSE-KMS encryption."
 }
 
 variable "site_url" {

--- a/variables.tf
+++ b/variables.tf
@@ -48,3 +48,9 @@ variable "cors_rules" {
   default     = []
   description = "cors policy rules"
 }
+
+variable "log_cookies" {
+  type        = bool
+  default     = false
+  description = "Include cookies in the CloudFront access logs."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "site_url" {
 }
 
 variable "wait_for_deployment" {
-  type        = string
+  type        = bool
   description = "Define if Terraform should wait for the distribution to deploy before completing."
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,8 +5,8 @@ variable "index_doc" {
 }
 
 variable "encryption_key_id" {
-  type = string
-  default = "aws/s3"
+  type        = string
+  default     = ""
   description = "The AWS KMS master key ID used for the SSE-KMS encryption."
 }
 


### PR DESCRIPTION
_This is what I'm going to do with Payment Manager. I wanted to do a PR so other people could see it and see if this is something we wanted to be implemented in the module._

This uses the Origin Access Identity feature in CloudFront to prevent access to an S3 bucket from everywhere except through a CloudFront distribution. It reduces the number of public entry points to an application from three (the CloudFront distribution URL, custom URL, and the S3 bucket URL) to two: just the CloudFront distribution URL and custom URL. This is helpful in cases where you want to protect the site with a WAF (like we will in Payment Manager) because the WAF can be assigned to the CloudFront distribution, protecting both publicly-accessible URLs. Using our current method, the WAF could be circumvented using the S3 bucket URL.

Additional changes include encrypting the bucket objects server-side, requiring that objects be accessed via HTTPS, and changing resource names to match with naming conventions.

The breaking changes include removing the ability to specify a custom error page for an S3 site and the origin path. This is because we are no longer using the public website functionality in S3 and are using the `s3_origin_config` in CloudFront instead of the `custom_origin_config`. 

References:
- https://aws.amazon.com/blogs/security/how-to-use-bucket-policies-and-apply-defense-in-depth-to-help-secure-your-amazon-s3-data/
- https://aws.amazon.com/premiumsupport/knowledge-center/cloudfront-serve-static-website/