### PR TITLE
Use Referer header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
           matrix='{
             "env":[
               {
-                "tf_version":"0.13.2",
+                "tf_version":"0.13.4",
                 "tf_working_dir":"./examples/ci-13",
                 "aws_key_name":"byu_oit_terraform_dev_key",
                 "aws_secret_name":"byu_oit_terraform_dev_secret"
               },
               {
-                "tf_version":"0.12.26",
+                "tf_version":"0.12.29",
                 "tf_working_dir":"./examples/ci-12",
                 "aws_key_name":"byu_oit_terraform_dev_key",
                 "aws_secret_name":"byu_oit_terraform_dev_secret"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ module "s3_site" {
 | forward_query_strings  | bool         | Forward query strings to the origin.                                             | `false`        |
 | encryption_key_arn     | string       | The ARN of the KMS key used to encrypt data in the S3 buckets.                   | aws/s3 ARN     |
 | log_cookies            | bool         | Include cookies in the CloudFront access logs.                                   | `false`        |
-| force_destroy          | bool         | Destroy site buckets even if they're not empty.                                  | `false`
+| force_destroy          | bool         | Destroy site buckets even if they're not empty on a `terraform destroy` command. | `false`
 ## Outputs
 | Name            | Type                                                                                                     | Description                                             |
 | --------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -35,11 +35,14 @@ module "s3_site" {
 | error_doc              | string      | The error document (e.g. 404 page) of the site.                                   | index.html     |
 | origin_path            | string      | The path to the file in the S3 bucket (no trailing slash).                        | *Empty string* |
 | site_url               | string      | The URL for the site.                                                             |
-| wait_for_deployment    | string      | Define if Terraform should wait for the distribution to deploy before completing. | `true`         |
+| wait_for_deployment    | bool        | Define if Terraform should wait for the distribution to deploy before completing. | `true`         |
 | s3_bucket_name         | string      | Name of S3 bucket for the website                                                 |
 | tags                   | map(string) | A map of AWS Tags to attach to each resource created                              | {}             |
 | cloudfront_price_class | string      | The price class for the cloudfront distribution                                   | PriceClass_100 |
 | cors_rules             | list(object) | The CORS policies for S3 bucket                                                  | []             |
+| forward_query_strings  | bool         | Forward query strings to the origin.                                             | `false`        |
+| encryption_key_arn     | string       | The ARN of the KMS key used to encrypt data in the S3 buckets.                   | aws/s3 ARN     |
+| log_cookies            | bool         | Include cookies in the CloudFront access logs.                                   | `false`        |
 ## Outputs
 | Name            | Type                                                                                                     | Description                                             |
 | --------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Terraform module deploys an S3-hosted static site with HTTPS enabled.
 ## Usage
 ```hcl
 module "s3_site" {
-  source    = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v4.0.1"
+  source    = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v5.0.0"
   site_url       = "my-site.byu.edu"
   hosted_zone_id = "zoneid"
   s3_bucket_name = "bucket-name"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ module "s3_site" {
 | forward_query_strings  | bool         | Forward query strings to the origin.                                             | `false`        |
 | encryption_key_arn     | string       | The ARN of the KMS key used to encrypt data in the S3 buckets.                   | aws/s3 ARN     |
 | log_cookies            | bool         | Include cookies in the CloudFront access logs.                                   | `false`        |
+| force_destroy          | bool         | Destroy site buckets even if they're not empty.                                  | `false`
 ## Outputs
 | Name            | Type                                                                                                     | Description                                             |
 | --------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |

--- a/examples/ci-12/ci.tf
+++ b/examples/ci-12/ci.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.12.26"
+  required_version = "0.12.29"
 }
 
 provider "aws" {

--- a/examples/ci-13/ci.tf
+++ b/examples/ci-13/ci.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.13.2"
+  required_version = "0.13.4"
 }
 
 provider "aws" {

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -10,7 +10,7 @@ data "aws_route53_zone" "zone" {
 }
 
 module "s3_site" {
-  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v4.0.1"
+  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v5.0.0"
   //  source         = "../../"
   site_url       = "teststatic.byu-oit-terraform-dev.amazon.byu.edu"
   hosted_zone_id = data.aws_route53_zone.zone.id

--- a/main.tf
+++ b/main.tf
@@ -2,11 +2,11 @@ terraform {
   required_version = ">= 0.12.16"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">= 3.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = ">= 3.0"
     }
   }
@@ -48,7 +48,7 @@ resource "aws_route53_record" "cert_validation" {
 }
 
 resource "random_string" "cf_key" {
-  length = 32
+  length  = 32
   special = false
 }
 
@@ -67,7 +67,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     }
 
     custom_header {
-      name = "Referer"
+      name  = "Referer"
       value = random_string.cf_key.result
     }
   }
@@ -138,8 +138,8 @@ resource "aws_route53_record" "custom_url_4a" {
 }
 
 resource "aws_s3_bucket" "website" {
-  bucket = var.s3_bucket_name
-  tags   = var.tags
+  bucket        = var.s3_bucket_name
+  tags          = var.tags
   force_destroy = var.force_destroy
 
   website {
@@ -191,8 +191,8 @@ data "aws_iam_policy_document" "static_website" {
     }
 
     condition {
-      test = "StringLike"
-      values = [random_string.cf_key.result]
+      test     = "StringLike"
+      values   = [random_string.cf_key.result]
       variable = "aws:Referer"
     }
   }
@@ -204,8 +204,8 @@ resource "aws_s3_bucket_policy" "static_website_read" {
 }
 
 resource "aws_s3_bucket" "logging" {
-  bucket = "${var.site_url}-access-logs"
-  tags   = var.tags
+  bucket        = "${var.site_url}-access-logs"
+  tags          = var.tags
   force_destroy = var.force_destroy
 
   lifecycle_rule {

--- a/main.tf
+++ b/main.tf
@@ -196,24 +196,6 @@ data "aws_iam_policy_document" "static_website" {
       variable = "aws:Referer"
     }
   }
-
-  statement {
-    sid       = "2"
-    effect    = "Deny"
-    actions   = ["s3:GetObject"]
-    resources = ["${aws_s3_bucket.website.arn}/*"]
-
-    condition {
-      test     = "Bool"
-      values   = ["false"]
-      variable = "aws:SecureTransport"
-    }
-
-    principals {
-      identifiers = ["*"]
-      type        = "*"
-    }
-  }
 }
 
 resource "aws_s3_bucket_policy" "static_website_read" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,5 +7,5 @@ output "cf_distribution" {
 }
 
 output "dns_record" {
-  value = aws_route53_record.custom-url-a
+  value = aws_route53_record.custom_url_a
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "site_url" {
 }
 
 variable "wait_for_deployment" {
-  type        = string
+  type        = bool
   description = "Define if Terraform should wait for the distribution to deploy before completing."
   default     = true
 }
@@ -53,4 +53,22 @@ variable "cors_rules" {
   type        = list(object({ allowed_headers = list(string), allowed_methods = list(string), allowed_origins = list(string), expose_headers = list(string), max_age_seconds = number }))
   default     = []
   description = "cors policy rules"
+}
+
+variable "forward_query_strings" {
+  type = bool
+  default = false
+  description = "Forward query strings to the origin."
+}
+
+variable "encryption_key_arn" {
+  type = string
+  default = ''
+  description = "The ARN of the KMS key used to encrypt data in the S3 buckets."
+}
+
+variable "log_cookies" {
+  type = bool
+  default = false
+  description = "Include cookies in the CloudFront access logs."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -56,25 +56,25 @@ variable "cors_rules" {
 }
 
 variable "forward_query_strings" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Forward query strings to the origin."
 }
 
 variable "encryption_key_arn" {
-  type = string
-  default = ''
+  type        = string
+  default     = ""
   description = "The ARN of the KMS key used to encrypt data in the S3 buckets."
 }
 
 variable "log_cookies" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Include cookies in the CloudFront access logs."
 }
 
 variable "force_destroy" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Destroy site buckets even if they're not empty."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -76,5 +76,5 @@ variable "log_cookies" {
 variable "force_destroy" {
   type        = bool
   default     = false
-  description = "Destroy site buckets even if they're not empty."
+  description = "Destroy site buckets even if they're not empty on a 'terraform destroy' command."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -72,3 +72,9 @@ variable "log_cookies" {
   default = false
   description = "Include cookies in the CloudFront access logs."
 }
+
+variable "force_destroy" {
+  type = bool
+  default = false
+  description = "Destroy site buckets even if they're not empty."
+}


### PR DESCRIPTION
Supercedes #17. Rather than use an origin access identity, we use the `Referer` header between CloudFront and S3. CloudFront will forward the `Referer` header with a random value (generated by the `random` provider) to the S3 bucket. The S3 bucket will deny all requests without that header. This again will force all legitimate traffic through the CloudFront distribution. While the S3 bucket can still be accessed directly, the caller would get a 403 error if it's missing that header.

No functionality is removed in this PR. The breaking change is changing the resource name of the Route 53 records to standardize on the naming convention we use.

The added functionality includes adding the `Referer` header, setting a variable to force destroy buckets, encrypting buckets, and adding standard CloudFront logging (real-time logging is dependent on https://github.com/terraform-providers/terraform-provider-aws/pull/14974).