### PR TITLE
Attach WAF

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Terraform module deploys an S3-hosted static site with HTTPS enabled.
 ## Usage
 ```hcl
 module "s3_site" {
-  source    = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v5.0.0"
+  source    = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v5.1.0"
   site_url       = "my-site.byu.edu"
   hosted_zone_id = "zoneid"
   s3_bucket_name = "bucket-name"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ module "s3_site" {
 | encryption_key_arn     | string       | The ARN of the KMS key used to encrypt data in the S3 buckets.                   | aws/s3 ARN     |
 | log_cookies            | bool         | Include cookies in the CloudFront access logs.                                   | `false`        |
 | force_destroy          | bool         | Destroy site buckets even if they're not empty on a `terraform destroy` command. | `false`
+| waf_acl_arn            | string       | The ARN of the WAF that should front the CloudFront distribution.                |
 ## Outputs
 | Name            | Type                                                                                                     | Description                                             |
 | --------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -10,7 +10,7 @@ data "aws_route53_zone" "zone" {
 }
 
 module "s3_site" {
-  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v5.0.0"
+  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v5.1.0"
   //  source         = "../../"
   site_url       = "teststatic.byu-oit-terraform-dev.amazon.byu.edu"
   hosted_zone_id = data.aws_route53_zone.zone.id

--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,7 @@ resource "aws_cloudfront_distribution" "cdn" {
   is_ipv6_enabled     = true
   default_root_object = var.index_doc
   aliases             = [var.site_url]
+  web_acl_id          = var.waf_acl_arn
 
   logging_config {
     bucket          = aws_s3_bucket.logging.bucket_domain_name

--- a/variables.tf
+++ b/variables.tf
@@ -78,3 +78,9 @@ variable "force_destroy" {
   default     = false
   description = "Destroy site buckets even if they're not empty on a 'terraform destroy' command."
 }
+
+variable "waf_acl_arn" {
+  type        = string
+  default     = ""
+  description = "The ARN of the WAF that should front the CloudFront distribution."
+}


### PR DESCRIPTION
To use WAFs with CloudFront, you have to attach them in the CF distribution. You can't use the WAF attachment resource.

- Add web acl id
- update version
