### PR TITLE
Use SSE-S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ module "s3_site" {
 | cloudfront_price_class | string      | The price class for the cloudfront distribution                                   | PriceClass_100 |
 | cors_rules             | list(object) | The CORS policies for S3 bucket                                                  | []             |
 | forward_query_strings  | bool         | Forward query strings to the origin.                                             | `false`        |
-| encryption_key_arn     | string       | The ARN of the KMS key used to encrypt data in the S3 buckets.                   | aws/s3 ARN     |
 | log_cookies            | bool         | Include cookies in the CloudFront access logs.                                   | `false`        |
 | force_destroy          | bool         | Destroy site buckets even if they're not empty on a `terraform destroy` command. | `false`
 | waf_acl_arn            | string       | The ARN of the WAF that should front the CloudFront distribution.                |

--- a/main.tf
+++ b/main.tf
@@ -173,7 +173,7 @@ resource "aws_s3_bucket" "website" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        sse_algorithm     = "AES256"
+        sse_algorithm = "AES256"
       }
     }
   }
@@ -236,7 +236,7 @@ resource "aws_s3_bucket" "logging" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        sse_algorithm     = "AES256"
+        sse_algorithm = "AES256"
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -173,8 +173,7 @@ resource "aws_s3_bucket" "website" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        sse_algorithm     = "aws:kms"
-        kms_master_key_id = var.encryption_key_arn == "" ? "alias/aws/s3" : var.encryption_key_arn
+        sse_algorithm     = "AES256"
       }
     }
   }
@@ -237,8 +236,7 @@ resource "aws_s3_bucket" "logging" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        sse_algorithm     = "aws:kms"
-        kms_master_key_id = var.encryption_key_arn == "" ? "alias/aws/s3" : var.encryption_key_arn
+        sse_algorithm     = "AES256"
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -61,12 +61,6 @@ variable "forward_query_strings" {
   description = "Forward query strings to the origin."
 }
 
-variable "encryption_key_arn" {
-  type        = string
-  default     = ""
-  description = "The ARN of the KMS key used to encrypt data in the S3 buckets."
-}
-
 variable "log_cookies" {
   type        = bool
   default     = false


### PR DESCRIPTION
Hidden in the AWS documentation is this: "Currently, OAI only supports SSE-S3, which means customers cannot use SSE-KMS with OAI." That's what I originally used and it returns 400 errors for every page. I assume the reason I didn't see this while testing was because of CloudFront and browser caching. This changes the module to use SSE-S3 rather than SSE-KMS which should work. I see it working at payments-dev.byu.edu, but I suggest who ever reviews this goes and checks it themselves.
