### PR TITLE
Change access-log bucket name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,20 +16,20 @@ jobs:
           matrix='{
             "env":[
               {
-                "tf_version":"0.13.4",
+                "tf_version":"0.13.7",
                 "tf_working_dir":"./examples/ci-13",
                 "aws_key_name":"byu_oit_terraform_dev_key",
                 "aws_secret_name":"byu_oit_terraform_dev_secret"
               },
               {
-                "tf_version":"0.12.29",
+                "tf_version":"0.12.31",
                 "tf_working_dir":"./examples/ci-12",
                 "aws_key_name":"byu_oit_terraform_dev_key",
                 "aws_secret_name":"byu_oit_terraform_dev_secret"
               }
             ]
           }'
-          echo "::set-env name=matrix::`echo $matrix | jq -c .`"
+          echo matrix=`echo $matrix | jq -c .` >> $GITHUB_ENV
 
     outputs:
       matrix: ${{ env.matrix }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Terraform module deploys an S3-hosted static site with HTTPS enabled.
 ## Usage
 ```hcl
 module "s3_site" {
-  source    = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v5.1.1"
+  source    = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v6.0.0"
   site_url       = "my-site.byu.edu"
   hosted_zone_id = "zoneid"
   s3_bucket_name = "bucket-name"

--- a/examples/ci-12/ci.tf
+++ b/examples/ci-12/ci.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.12.29"
+  required_version = "0.12.31"
 }
 
 provider "aws" {

--- a/examples/ci-13/ci.tf
+++ b/examples/ci-13/ci.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.13.4"
+  required_version = "0.13.7"
 }
 
 provider "aws" {

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -10,7 +10,7 @@ data "aws_route53_zone" "zone" {
 }
 
 module "s3_site" {
-  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v5.1.1"
+  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v5.1.2"
   //  source         = "../../"
   site_url       = "teststatic.byu-oit-terraform-dev.amazon.byu.edu"
   hosted_zone_id = data.aws_route53_zone.zone.id

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -10,7 +10,7 @@ data "aws_route53_zone" "zone" {
 }
 
 module "s3_site" {
-  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v5.1.2"
+  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v6.0.0"
   //  source         = "../../"
   site_url       = "teststatic.byu-oit-terraform-dev.amazon.byu.edu"
   hosted_zone_id = data.aws_route53_zone.zone.id

--- a/main.tf
+++ b/main.tf
@@ -204,7 +204,7 @@ resource "aws_s3_bucket_policy" "static_website_read" {
 }
 
 resource "aws_s3_bucket" "logging" {
-  bucket        = "${var.site_url}-access-logs"
+  bucket        = "${var.s3_bucket_name}-access-logs"
   tags          = var.tags
   force_destroy = var.force_destroy
 


### PR DESCRIPTION
I got an error saying the bucket name was too long for this when working on the hw-static-site template. This will fix that. Would this be a breaking change?
