### PR TITLE
Hotfix/errordoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Terraform module deploys an S3-hosted static site with HTTPS enabled.
 ## Usage
 ```hcl
 module "s3_site" {
-  source    = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v7.0.0"
+  source    = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v7.0.1"
   site_url       = "my-site.byu.edu"
   hosted_zone_id = "zoneid"
   s3_bucket_name = "bucket-name"

--- a/examples/multi-domain/multi-domain.tf
+++ b/examples/multi-domain/multi-domain.tf
@@ -24,7 +24,7 @@ data "aws_route53_zone" "myotherapp" {
 }
 
 module "s3_site" {
-  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v7.0.0"
+  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v7.0.1"
   //source         = "../../"
   //site_url       = "myapp.byu.edu"
   site_url       = "myapp.byu-oit-terraform-dev.amazon.byu.edu"

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -10,7 +10,7 @@ data "aws_route53_zone" "zone" {
 }
 
 module "s3_site" {
-  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v7.0.0"
+  source = "github.com/byu-oit/terraform-aws-s3staticsite?ref=v7.0.1"
   //  source         = "../../"
   site_url       = "teststatic.byu-oit-terraform-dev.amazon.byu.edu"
   hosted_zone_id = data.aws_route53_zone.zone.id

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_cloudfront_distribution" "cdn" {
 
   # The custom error responses make SPA frameworks like Vue work.
   # This is setup to be fairly similar to how the module previously
-  # worked with the s3 static website "error_doc" field
+  # worked with the s3 static website "error_document" field
 
   custom_error_response {
     error_code         = 404

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "aws_cloudfront_distribution" "cdn" {
   # The custom error responses make SPA frameworks like Vue work.
   # This is setup to be fairly similar to how the module previously
   # worked with the s3 static website "error_doc" field
-  
+
   custom_error_response {
     error_code         = 404
     response_code      = 404

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,10 @@ resource "aws_cloudfront_distribution" "cdn" {
     origin_access_control_id = aws_cloudfront_origin_access_control.oac.id
   }
 
+  # The custom error responses make SPA frameworks like Vue work.
+  # This is setup to be fairly similar to how the module previously
+  # worked with the s3 static website "error_doc" field
+  
   custom_error_response {
     error_code         = 404
     response_code      = 404

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,18 @@ resource "aws_cloudfront_distribution" "cdn" {
     origin_access_control_id = aws_cloudfront_origin_access_control.oac.id
   }
 
+  custom_error_response {
+    error_code         = 404
+    response_code      = 404
+    response_page_path = var.error_doc
+  }
+
+  custom_error_response {
+    error_code         = 403
+    response_code      = 403
+    response_page_path = var.error_doc
+  }
+
   comment             = "CDN for ${var.site_url}"
   enabled             = true
   is_ipv6_enabled     = true


### PR DESCRIPTION
Correctly send 403 and 404 error from S3 to a custom error document. It should have already been doing this and this fixes a major problem where routing doesn't work correctly for SPA frameworks like Vue.